### PR TITLE
Allow overriding environment variables and add env expansion

### DIFF
--- a/files/kafka-connect.sh
+++ b/files/kafka-connect.sh
@@ -5,7 +5,7 @@ set -e
 
 # Functions
 
-use() {
+usage() {
     echo "kafka-connect.sh [--servercfg server.cfg] name name_1|file connector_cfg_1 [name name_2|file connector_cfg_2 .. name name_n|file connector_cfg_n] "
     echo "  name : set that connector_cfg is a name that will be used to load"
     echo "    configuration from /etc/kafka-connect/connector_cfg.properties"
@@ -24,7 +24,7 @@ start_server() {
 
 if [ -z "$1" ]
 then
-  use
+  usage
   exit 1
 fi
 
@@ -37,7 +37,7 @@ while [ -n "$1" ]; do
     --server)
       if [ "$2" == "" ]
       then
-        use
+        usage
         exit 1
       else
         server_cfg_file="$2"
@@ -53,7 +53,7 @@ while [ -n "$1" ]; do
       shift
       ;;
     *)
-      use
+      usage
       exit 1
       ;;
   esac

--- a/files/kafka-connect.sh
+++ b/files/kafka-connect.sh
@@ -6,13 +6,43 @@ set -e
 # Functions
 
 usage() {
-    echo "kafka-connect.sh [--servercfg server.cfg] name name_1|file connector_cfg_1 [name name_2|file connector_cfg_2 .. name name_n|file connector_cfg_n] "
-    echo "  name : set that connector_cfg is a name that will be used to load"
-    echo "    configuration from /etc/kafka-connect/connector_cfg.properties"
-    echo "  file : set that connector_cfg is a path to a file with connector config"
-    echo "    name test is the same like file /etc/kafka-connect/test.properties"
-    echo "  server.cfg path to kafka connect server."
-    echo "    By default is /etc/kafka-connect/connect.properties"
+    cat <<EOF
+Usage:
+
+      kafka-connect.sh [--servercfg <server.cfg>]
+                        name <name_1> | file <connector_cfg_1>
+		       [name <name_2> | file <connector_cfg_2>
+                       [name <name_3> | file <connector_cfg_3>
+		       [ ... e]]]
+
+  name : set that connector_cfg is a name that will be used to load
+    configuration from /etc/kafka-connect/connector_cfg.properties
+  file : set that connector_cfg is a path to a file with connector config
+    name test is the same like file /etc/kafka-connect/test.properties
+  server.cfg path to kafka connect server.
+    By default is /etc/kafka-connect/connect.properties
+
+Features:
+
+The properties files can include environment variables which will be
+replaced in this environment.
+
+E.g.,
+
+    connection.url=http://\${ES_HOST:-elasticsearch}:\${ES_PORT:-9200}
+
+will be replaced by whichever values of ES_HOST and ES_PORT may be
+available in the environment, falling back to "elasticsearch" and 9200
+respectively. The syntax accepts ${VAR} as environment variables, with
+replacement possibilities as offered by bash (e.g., :- for default
+values).
+
+Also, if some variable is to be completely replaced, you can pass a
+variable KC_OVERRIDE_PROPERTY_NAME=value in order to set
+property.name=value.
+
+EOF
+
 }
 
 

--- a/files/kafka-connect.sh
+++ b/files/kafka-connect.sh
@@ -20,6 +20,43 @@ start_server() {
   connect-standalone.sh $@
 }
 
+expandVarsStrict() {
+    # Originally from http://stackoverflow.com/a/40167919/488191
+    # Excerpt under CC-By-SA 3.0 by http://stackoverflow.com/users/45375/
+
+    local line lineEscaped
+    while IFS= read -r line || [[ -n $line ]]; do # the `||` clause ensures that the last line is read even if it doesn't end with \n
+	# Escape ALL chars. that could trigger an expansion
+	IFS= read -r -d '' lineEscaped < <(printf %s "$line" | tr '`([$' '\1\2\3\4')
+	# ... then selectively reenable ${ references
+	lineEscaped=${lineEscaped//$'\4{'/\$'{'}
+	# Finally, escape embedded double quotes to preserve them.
+	lineEscaped=${lineEscaped//\"/\\\"}
+	eval "printf '%s\n' \"$lineEscaped\"" | tr '\1\2\3\4' '`([$'
+    done
+}
+
+resolve_variables() {
+    for VAR in `env`
+    do
+	if [[ $VAR =~ ^KC_OVERRIDE_ ]]; then
+	    kconnect_name=$(echo "$VAR" | sed -r 's/KC_OVERRIDE_(.*)=.*/\1/g' | tr '[:upper:]' '[:lower:]' | tr _ .)
+	    env_var=$(echo "$VAR" | sed -r 's/(.*)=.*/\1/g')
+
+	    if egrep -q "(^|^#)$kconnect_name=" "$1"; then
+		sed -r -i "s@(^|^#)($kconnect_name)=(.*)@\2=${!env_var}@g" "$1"
+	    else
+		echo "Preexisting variable $kconnect_name not found at $1" >&2
+	    fi
+	fi
+
+	expandVarsStrict < "$1" > "$1.exp.properties"
+
+	echo "$1.exp.properties"
+    done
+}
+
+
 # Main
 
 if [ -z "$1" ]
@@ -45,11 +82,11 @@ while [ -n "$1" ]; do
       fi
       ;;
     name)
-      connectors_cfg+=("/etc/kafka-connect/${2}.properties")
+      connectors_cfg+=($(resolve_variables "/etc/kafka-connect/${2}.properties"))
       shift
       ;;
     file)
-      connectors_cfg+=("$2")
+      connectors_cfg+=($(resolve_variables "$2"))
       shift
       ;;
     *)


### PR DESCRIPTION
Now properties files support the `${VARIABLE}` and even the
`${VARIABLE:-default-value}` syntax so that they can be replaced by
environment variables in production settings.

The kafka-connect.sh launcher also supports replacing variables that
are already in the properties file by using the following convention:
```
KC_OVERRIDE_CONNECTION_URL=http://elastic.svc.cluster.local:80
```
will replace all occurrences of the connection.url variable for
```
connection.url=http://elastic.svc.cluster.local:80
```
That is, all variables are transformed to lowercase and underscores to
dots.