### PR TITLE
On fly parametrization is based on command line options.

### DIFF
--- a/files/kafka-connect.sh
+++ b/files/kafka-connect.sh
@@ -9,37 +9,45 @@ usage() {
     cat <<EOF
 Usage:
 
-      kafka-connect.sh [--servercfg <server.cfg>]
-                        name <name_1> | file <connector_cfg_1>
-                       [name <name_2> | file <connector_cfg_2>
-                       [name <name_3> | file <connector_cfg_3>
-                       [ ... e]]]
+  kafka-connect.sh
+    [ --servercfg <server.cfg> ]
+    name <name_1> | file <connector_cfg_1>
+    [ name <name_2> | file <connector_cfg_2> ... name <name_n> | file <connector_cfg_n> ]
+    [ --config-props <property=value_1> [<property=value_2> ... <property=value_n> ]
+    [ --config-props-over-name <name_1> <property=value_1> [<property=value_2> ... <property=value_n> ]]
+    ...
+    [ --config-props-over-name <name_n> <property=value_1> [<property=value_2> ... <property=value_n> ]]
+    [ --config-props-over-file <file_1> <property=value_1> [<property=value_2> ... <property=value_n> ]]
+    ...
+    [ --config-props-over-file <file_n> <property=value_1> [<property=value_2> ... <property=value_n> ]]
 
-  name : set that connector_cfg is a name that will be used to load
-    configuration from /etc/kafka-connect/connector_cfg.properties
-  file : set that connector_cfg is a path to a file with connector config
-    name test is the same like file /etc/kafka-connect/test.properties
-  server.cfg path to kafka connect server.
+  name : set that <name_n> is a name that will be used to load
+    configuration from /etc/kafka-connect/<name_n>.properties
+
+  file : set that <connector_cfg> is a path to a file with connector config
+  <server.cfg> path to kafka connect server.
     By default is /etc/kafka-connect/connect.properties
 
-Features:
+  --config-props define propeties to be added/override "on-fly" over all
+    connector names/files,
 
-The properties files can include environment variables which will be
-replaced in this environment.
+    <propperty=value_n> is the property to be added or override in configuration file.
+    property=value_n will be directly append to a configuration file just after remove
+    all properties that matchs with '^property[ \t]*=' regular expression.
 
-E.g.,
+  --config-props-over-name Similar to --config-props but is appliend only on connector
+    name configuration.
 
-    connection.url=http://\${ES_HOST:-elasticsearch}:\${ES_PORT:-9200}
+    <name_n>. It is the name of connector when use "name <name_X>"
 
-will be replaced by whichever values of ES_HOST and ES_PORT may be
-available in the environment, falling back to "elasticsearch" and 9200
-respectively. The syntax accepts ${VAR} as environment variables, with
-replacement possibilities as offered by bash (e.g., :- for default
-values).
+  --config-props-over-file Similar to --config-props-over-name but is applided on
+    file configuration of connector, server.cfg file can be set too.
 
-Also, if some variable is to be completely replaced, you can pass a
-variable KC_OVERRIDE_PROPERTY_NAME=value in order to set
-property.name=value.
+    <file_n>. It is the path file of connector (file <connector_cfg_n>) or value of
+    <server.cfg>
+
+  NOTE: For simplification of the algorithm --config-props, --config-props-over-name,
+  and --config-props-over-file options must be set at end of command line.
 
 EOF
 
@@ -50,39 +58,35 @@ start_server() {
   connect-standalone.sh $@
 }
 
-expandVarsStrict() {
-    # Originally from http://stackoverflow.com/a/40167919/488191
-    # Excerpt under CC-By-SA 3.0 by http://stackoverflow.com/users/45375/
+edit_file() {
+  local file_name="$1"
+  local propertiesApplided=0
+  shift
+  while [[ "$1" =~ ([^= ]+)=.* ]]; do
 
-    local line lineEscaped
-    while IFS= read -r line || [[ -n $line ]]; do # the `||` clause ensures that the last line is read even if it doesn't end with \n
-        # Escape ALL chars. that could trigger an expansion
-        IFS= read -r -d '' lineEscaped < <(printf %s "$line" | tr '`([$' '\1\2\3\4')
-        # ... then selectively reenable ${ references
-        lineEscaped=${lineEscaped//$'\4{'/\$'{'}
-        # Finally, escape embedded double quotes to preserve them.
-        lineEscaped=${lineEscaped//\"/\\\"}
-        eval "printf '%s\n' \"$lineEscaped\"" | tr '\1\2\3\4' '`([$'
-    done
+    # Extract property name
+    local property_name=${BASH_REMATCH[1]}
+
+    # Remove exisitng property in file if exists
+    local tempFile=$(mktemp)
+    egrep -ve "^[[:space:]]*${property_name}[[:space:]]*=" $file_name > "$tempFile"
+    mv -f "$tempFile" "$file_name"
+
+    #Append to end
+    echo "" >> "$file_name"
+    echo "#ON-FLY configurration maybe original value was removed above" >> "$file_name"
+    echo "$1" >> "$file_name"
+
+    shift
+    propertiesApplided=$((propertiesApplided + 1))
+  done
+
+  echo -n "$propertiesApplided"
 }
 
-resolve_variables() {
-    for VAR in `env`
-    do
-        if [[ $VAR =~ ^KC_OVERRIDE_ ]]; then
-            kconnect_name=$(echo "$VAR" | sed -r 's/KC_OVERRIDE_(.*)=.*/\1/g' | tr '[:upper:]' '[:lower:]' | tr _ .)
-            env_var=$(echo "$VAR" | sed -r 's/(.*)=.*/\1/g')
-
-            if egrep -q "(^|^#)$kconnect_name=" "$1"; then
-                sed -r -i "s@(^|^#)($kconnect_name)=(.*)@\2=${!env_var}@g" "$1"
-            else
-                echo "Preexisting variable $kconnect_name not found at $1" >&2
-            fi
-        fi
-
-    done
-    expandVarsStrict < "$1" > "$1.exp.properties"
-    echo "$1.exp.properties"
+rm_temp_path() {
+  echo "Removing temporal path $1"
+  rm -fr "$1"
 }
 
 
@@ -97,6 +101,15 @@ fi
 # Default config
 server_cfg_file="/etc/kafka-connect/connect.properties"
 
+# Creating TEMP_PATH
+WORKINGPATH=$(mktemp -d --suffix="-kafka-connect-sh")
+echo "Working configuration path set to $WORKINGPATH"
+if [ -f "$server_cfg_file" ]; then
+  server_cfg_file_basename="$(basename $server_cfg_file)"
+  cp "$server_cfg_file" "$WORKINGPATH/"
+  server_cfg_file="$WORKINGPATH/$server_cfg_file_basename"
+fi
+
 connectors_cfg=()
 while [ -n "$1" ]; do
   case $1 in
@@ -107,27 +120,118 @@ while [ -n "$1" ]; do
         exit 1
       else
         server_cfg_file="$2"
-        shift
+        server_cfg_file_basename="$(basename $server_cfg_file)"
+        cp "$server_cfg_file" "$WORKINGPATH/"
+        server_cfg_file="$WORKINGPATH/$server_cfg_file_basename"
+        shift 2
       fi
       ;;
     name)
-      connectors_cfg+=($(resolve_variables "/etc/kafka-connect/${2}.properties"))
-      shift
+      if [ -f "/etc/kafka-connect/${2}.properties" ]; then
+        cp "/etc/kafka-connect/${2}.properties" "$WORKINGPATH/${2}.properties"
+        connectors_cfg+=("$WORKINGPATH/${2}.properties")
+      else
+        echo "/etc/kafka-connect/${2}.properties did not find. Ignored"
+      fi
+      shift 2
       ;;
     file)
-      connectors_cfg+=($(resolve_variables "$2"))
+      if [ -f "${2}" ]; then
+        cfg_file_base_name="$(basename $2)"
+        cp "${2}" "$WORKINGPATH/"
+        connectors_cfg+=("$WORKINGPATH/${cfg_file_base_name}")
+      else
+        echo "${2} did not find. Ignored"
+      fi
+      shift 2
+      ;;
+    --config-props)
+      if [ -z "$2" ]; then
+        echo "--config-props without any option"
+        usage
+        exit 1
+      fi
       shift
+      paramstToShift=0
+      for f in $WORKINGPATH/*; do
+        if [ "$f" != "$server_cfg_file" ]; then
+          echo "Editing on-fly configuration file $f"
+          paramstToShift=$(edit_file "$f" "$@")
+        fi
+      done
+
+      # Shift parameters applied on edit_file
+      shift $paramstToShift
+      ;;
+    --config-props-over-name)
+      if [ -z "$2" ]; then
+        echo "--config-props-over-name without name"
+        usage
+        exit 1
+      fi
+      name="$2"
+      shift 2
+      if [ -z "$1" ]; then
+        echo "--config-props-over-name without any option"
+        usage
+        exit 1
+      fi
+      if [ ! -f $WORKINGPATH/$name.properties ]; then
+        echo "--config-props-over-name $name set does not exist. Ignoring"
+        # Clean current --config-props-over-name
+        while [[ "$1" =~ ..*=.* ]]; do
+          shift
+        done
+      else
+        echo "Editing on-fly connector $name file $WORKINGPATH/$name.properties"
+        paramstToShift=$(edit_file "$WORKINGPATH/$name.properties" "$@")
+
+        # Shift parameters applied on edit_file
+        shift $paramstToShift
+      fi
+      ;;
+    --config-props-over-file)
+      if [ -z "$2" ]; then
+        echo "--config-props-over-file without file-name"
+        usage
+        exit 1
+      fi
+      fullName=$2
+      name="$(basename $2)"
+      shift 2
+      if [ -z "$1" ]; then
+        echo "--config-props-over-file without any option"
+        usage
+        exit 1
+      fi
+      if [ ! -f $WORKINGPATH/$name ]; then
+        echo "--config-props-over-file file set does not exist. Ignoring"
+        # Clean current --config-props-over-name
+        while [[ "$1" =~ ..*=.* ]]; do
+          shift
+        done
+      else
+        echo "Editing on-fly cofiguration file $fullName (working file $WORKINGPATH/$name)"
+        paramstToShift=$(edit_file "$WORKINGPATH/$name" "$@")
+
+        # Shift parameters applied on edit_file
+        shift $paramstToShift
+      fi
       ;;
     *)
+      echo "Unknown option $1"
       usage
       exit 1
       ;;
   esac
-  shift
 done
 
-start_server "${server_cfg_file}" ${connectors_cfg[@]}
+if [ -z ${connectors_cfg} ]; then
+  rm_temp_path $WORKINGPATH
+  echo "Connectors list empty"
+  usage
+  exit 1
+fi
 
-# Local Variables:
-# indent-tabs-mode: nil
-# End:
+echo "launhing servers start_server "${server_cfg_file}" ${connectors_cfg[@]}"
+start_server "${server_cfg_file}" ${connectors_cfg[@]}


### PR DESCRIPTION
Old fashion based on environment variables is deprecated for next reasons:

* Some cases like set a property with name prop_sub_propb_b=value was not allowed.

* In-place environment variables into java properties (`${ENV-VAR:-default-value}`) are not java properties standar and can be collide with future java application values.

**TO-DO** load from environment variables but in a compliance with new on-fly parametrization mode.