### PR TITLE
Feature/healtcheck and remove if exists connectors on distributed mode

### DIFF
--- a/files/kafka-connect.sh
+++ b/files/kafka-connect.sh
@@ -131,6 +131,31 @@ launch_over_distributed_worker() {
 }
 
 ##
+# Checks if connector loaded from configuratin exists, if exists return connector name.
+# Else return empty string
+##
+# PARAMS
+##
+#   $1 endpoint (i.e http://localhost:8083) of distributed worker cluster.
+#   $2 onnectors configurations
+##
+check_exist_in_distributed(){
+  local end_point="$1/connectors"
+  shift
+  # extract name
+  local name=$(cat "$1" | egrep -oe '^[[:space:]]*name[[:space:]]*=.*' | sed 's/[^= ]*= *//')
+  local error_code=$(curl "$end_point/$name/status" | jq '.error_code' 2> /dev/null)
+
+  # With error_code null connector exists
+  if [ "$error_code" == "null" ]; then
+    echo -n $name
+  else
+    echo -n ""
+  fi
+}
+
+
+##
 # PARAMS
 ##
 #  $1 check mode, allowed values

--- a/files/kafka-connect.sh
+++ b/files/kafka-connect.sh
@@ -14,7 +14,7 @@ Usage:
 
   kafka-connect.sh
     [ --servercfg <server.cfg> ]
-    [ --distributed-end-point <url> [--health-check-all | --health-check-one]]
+    [ --distributed-end-point <url> [--health-check-all | --health-check-one] [--force-remove]]
     start-distributed-worker | name <name_1> | file <connector_cfg_1>
     [ name <name_2> | file <connector_cfg_2> ... name <name_n> | file <connector_cfg_n> ]
     [ --config-props <property_1=value_1> [<property_2=value_2> ... <property_n=value_n> ]
@@ -47,6 +47,9 @@ Usage:
 
     --health-check-one: Current program will finish with exit status 2 when one
     job connetor will have not any task in running mode.
+
+  --force-remove: If present and connector exists with same name. Existing connector
+    will be removed before launch connector over distributed cluster.
 
   start-distributed-worker: Stars worker node based on configuration of server.cfg
     In this case any connector will be launched, only a worker node.

--- a/files/kafka-connect.sh
+++ b/files/kafka-connect.sh
@@ -95,6 +95,7 @@ start_server_worker() {
 # PARAMS
 ##
 #  $1 endpoint (i.e http://localhost:8083) of distributed worker cluster.
+#  $2..$@ connectors configurations
 launch_over_distributed_worker() {
   local end_point="${1}/connectors"
   shift

--- a/files/kafka-connect.sh
+++ b/files/kafka-connect.sh
@@ -14,7 +14,7 @@ Usage:
 
   kafka-connect.sh
     [ --servercfg <server.cfg> ]
-    [ --distributed-end-point <url> ]
+    [ --distributed-end-point <url> [--health-check-all | --health-check-one]]
     start-distributed-worker | name <name_1> | file <connector_cfg_1>
     [ name <name_2> | file <connector_cfg_2> ... name <name_n> | file <connector_cfg_n> ]
     [ --config-props <property_1=value_1> [<property_2=value_2> ... <property_n=value_n> ]
@@ -35,6 +35,18 @@ Usage:
   --distributed-end-point <url>: If this opition is present, connectors will be
     launched using REST service behind this <url> end point.
     After response of REST service current process will be end.
+
+  --health-check-one and --health-check-all. When one of this option is present
+    and --distributed-end-point is active too, current program does not finish
+    just after launchs connector over distributed cluster (default). Instead of
+    this current program will remaining checking at least one task per connector
+    is running:
+
+    --health-check-all: Current program will finish with exit status 2 if there
+    are not any job with at least one task in running mode.
+
+    --health-check-one: Current program will finish with exit status 2 when one
+    job connetor will have not any task in running mode.
 
   start-distributed-worker: Stars worker node based on configuration of server.cfg
     In this case any connector will be launched, only a worker node.

--- a/files/kafka-connect.sh
+++ b/files/kafka-connect.sh
@@ -154,6 +154,22 @@ check_exist_in_distributed(){
   fi
 }
 
+##
+# Delete existing job by name
+##
+# PARAMS
+##
+#   $1 endpoint (i.e http://localhost:8083) of distributed worker cluster.
+#   $2 connectors name
+##
+delete_by_name_in_distributed(){
+  if [ -n "$2" ]; then
+    local end_point="$1/connectors/$2"
+    echo "Deleting job $2 ($end_point)"
+
+    curl -XDELETE "$end_point"
+  fi
+}
 
 ##
 # PARAMS


### PR DESCRIPTION
Now is supported:

- Continuously health-check when launch one or more connectors on distributed mode.
- Force remove just before launch connector if exists one with same connector name.